### PR TITLE
Feature/land mesh2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,6 @@ dependencies = [
  "futures-util",
  "itertools",
  "quinn",
- "rayon",
  "rmp-serde",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,9 @@ dependencies = [
  "deflate",
  "futures",
  "futures-util",
+ "itertools",
  "quinn",
+ "rayon",
  "rmp-serde",
  "rustls",
  "serde",
@@ -1691,6 +1693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ deflate = "0.8.6"
 
 futures-util = "0.3.5"
 uuid = { version = "0.8", features = ["v4"] }
+rayon = "1.4.0"
+itertools = "0.9.0"
 
 # rustls isn't directly needed, it's a dependency of `quinn`. The `dangerous_configuration` feature is required to bypass security in the networking.
 # Make sure to recheck this versaion number when updating quinn!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ deflate = "0.8.6"
 
 futures-util = "0.3.5"
 uuid = { version = "0.8", features = ["v4"] }
-rayon = "1.4.0"
 itertools = "0.9.0"
 
 # rustls isn't directly needed, it's a dependency of `quinn`. The `dangerous_configuration` feature is required to bypass security in the networking.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -71,7 +71,7 @@ fn setup(
         mesh: meshes.add(land_mesh),
         material: materials.add(StandardMaterial {
             albedo_texture: Some(land_texture_top_handle),
-            shaded: false,
+            shaded: true,
             ..Default::default()
         }),
         translation: Translation::new(4.0, 1.5, 4.0),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -6,7 +6,7 @@ use bevy::{
     prelude::*,
     render::mesh::shape,
 };
-use bounded_planet::{camera::*, land::mesh::*};
+use bounded_planet::{camera::*, land::*, land::TextureHeightmap};
 
 // The thresholds for window edge.
 const CURSOR_H_THRESHOLD: f32 = 0.55;
@@ -53,7 +53,7 @@ fn setup(
     mut sounds: ResMut<Assets<AudioSource>>,
 ) {
     let land_texture_handle = asset_server
-        .load_sync(&mut textures, "src/media/CoveWorld.png")
+        .load_sync(&mut textures, "src/media/CoveWorldtest.png")
         .expect("Failed to load CoveWorld.png");
 
     let land_texture_top_handle = asset_server
@@ -64,14 +64,13 @@ fn setup(
         .load_sync(&mut sounds, "src/media/test_sound.mp3")
         .expect("Failed to load test_sound.mp3");
 
-    let land_mesh =
-        texture_to_mesh(textures, land_texture_handle).expect("Couldn't turn texture to mesh");
+    let wrap = TextureHeightmap::new(textures.get(&land_texture_handle).expect("Couldn't get texture")).expect("Couldn't wrap texture");
+    let land_mesh = texture_to_mesh(&wrap).expect("Couldn't turn texture to mesh");
 
     commands.spawn(PbrComponents {
         mesh: meshes.add(land_mesh),
         material: materials.add(StandardMaterial {
             albedo_texture: Some(land_texture_top_handle),
-            shaded: false,
             ..Default::default()
         }),
         translation: Translation::new(4.0, 1.5, 4.0),
@@ -90,6 +89,11 @@ fn setup(
         // light
         .spawn(LightComponents {
             translation: Translation::new(4.0, 8.0, 4.0),
+            light: Light {
+                color: Color::WHITE,
+                fov: 90f32,
+                depth: 0f32..100.0
+            },
             ..Default::default()
         })
         // camera

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -71,6 +71,7 @@ fn setup(
         mesh: meshes.add(land_mesh),
         material: materials.add(StandardMaterial {
             albedo_texture: Some(land_texture_top_handle),
+            shaded: false,
             ..Default::default()
         }),
         translation: Translation::new(4.0, 1.5, 4.0),

--- a/src/land/bintree.rs
+++ b/src/land/bintree.rs
@@ -1,6 +1,0 @@
-use bevy::prelude::{Mesh, Texture};
-
-pub fn texture_to_mesh2(heightmap: &Texture) -> Mesh
-{
-    unimplemented!();
-}

--- a/src/land/bintree.rs
+++ b/src/land/bintree.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::{Mesh, Texture};
+
+pub fn texture_to_mesh2(heightmap: &Texture) -> Mesh
+{
+    unimplemented!();
+}

--- a/src/land/heightmap.rs
+++ b/src/land/heightmap.rs
@@ -9,7 +9,7 @@ pub trait HeightmapData
 {
     /// Get the bounds of this heightmap (x, y).
     /// Sampled values must be in the [0, size-1] range.
-    fn size(&self) -> (u32, u32);
+    fn size(&self) -> (u16, u16);
 
     /// Sample a height from the heightmap. This allows reads one either side of the size, i.e. `-1` and `size().0` are valid sample positions
     fn sample(&self, x:i32, y:i32) -> Result<f32, SamplingError>;
@@ -18,7 +18,7 @@ pub trait HeightmapData
 /// Wrap a texture as a heightmap
 pub struct TextureHeightmap<'a> {
     pub texture: &'a Texture,
-    size: (u32, u32),
+    size: (u16, u16),
 }
 
 #[derive(Debug)]
@@ -36,14 +36,14 @@ impl<'a> TextureHeightmap<'a> {
 
         Ok(TextureHeightmap {
             texture,
-            size: (texture.size.x() as u32 - 2, texture.size.y() as u32 - 2),
+            size: (texture.size.x() as u16 - 2, texture.size.y() as u16 - 2),
         })
     }
 }
 
 impl<'a> HeightmapData for TextureHeightmap<'a>
 {
-    fn size(&self) -> (u32, u32) {
+    fn size(&self) -> (u16, u16) {
         self.size
     }
 

--- a/src/land/heightmap.rs
+++ b/src/land/heightmap.rs
@@ -1,0 +1,78 @@
+use bevy::{prelude::Texture, render::texture::TextureFormat};
+
+#[derive(Debug)]
+pub enum SamplingError {
+    ReadOutOfBounds()
+}
+
+pub trait HeightmapData
+{
+    /// Get the bounds of this heightmap (x, y).
+    /// Sampled values must be in the [0, size-1] range.
+    fn size(&self) -> (u32, u32);
+
+    /// Sample a height from the heightmap.
+    fn sample(&self, x:u32, y:u32) -> Result<f32, SamplingError>;
+}
+
+/// Wrap a texture as a heightmap
+pub struct TextureHeightmap<'a> {
+    pub texture: &'a Texture,
+    size: (u32, u32),
+
+    pixel_bytes: u8,
+    chan_start: usize,
+    chan_end: usize,
+}
+
+#[derive(Debug)]
+pub enum WrapError {
+    UnsupportedFormat(TextureFormat),
+}
+
+impl<'a> TextureHeightmap<'a> {
+    pub fn new(texture: &Texture) -> Result<TextureHeightmap, WrapError>
+    {
+        // For now we only support 1 single texture format
+        if texture.format != TextureFormat::R8Unorm {
+            return Err(WrapError::UnsupportedFormat(texture.format));
+        }
+
+        return Ok(TextureHeightmap {
+            texture,
+            size: (texture.size.x() as u32, texture.size.y() as u32),
+
+            // Because we only support 1 format these are constants
+            pixel_bytes: 1,
+            chan_start: 0,
+            chan_end: 0
+        });
+    }
+}
+
+impl<'a> HeightmapData for TextureHeightmap<'a>
+{
+    fn size(&self) -> (u32, u32) {
+        self.size
+    }
+
+    fn sample(&self, x:u32, y:u32) -> Result<f32, SamplingError>
+    {
+        // Sanity check that read coordinates are in bounds
+        if x >= self.size.0 || y > self.size.1 {
+            return Err(SamplingError::ReadOutOfBounds())
+        }
+
+        // Work of the coordinate in the data array of the bytes for this pixel
+        let i = x * (self.pixel_bytes as u32)                // Offset by columns
+              + y * (self.pixel_bytes as u32) * self.size.1; // Offset by rows
+
+        // Currently we only support one texture format (R8UNORM), so implementing this very simple...
+
+        // Get the byte
+        let data = self.texture.data[i as usize] as f32;
+
+        // Remap it to the right range
+        return Ok(data);
+    }
+}

--- a/src/land/heightmap.rs
+++ b/src/land/heightmap.rs
@@ -12,7 +12,7 @@ pub trait HeightmapData
     fn size(&self) -> (u16, u16);
 
     /// Sample a height from the heightmap. This allows reads one either side of the size, i.e. `-1` and `size().0` are valid sample positions
-    fn sample(&self, x:i32, y:i32) -> Result<f32, SamplingError>;
+    fn sample(&self, x: i32, y: i32) -> Result<f32, SamplingError>;
 }
 
 /// Wrap a texture as a heightmap
@@ -47,7 +47,7 @@ impl<'a> HeightmapData for TextureHeightmap<'a>
         self.size
     }
 
-    fn sample(&self, x:i32, y:i32) -> Result<f32, SamplingError>
+    fn sample(&self, x: i32, y: i32) -> Result<f32, SamplingError>
     {
         // Sanity check that read coordinates are in bounds
         if (x > i32::from(self.size.0)) || (y > i32::from(self.size.1)) || (y < -1) || (x < -1) {

--- a/src/land/heightmap.rs
+++ b/src/land/heightmap.rs
@@ -50,7 +50,7 @@ impl<'a> HeightmapData for TextureHeightmap<'a>
     fn sample(&self, x:i32, y:i32) -> Result<f32, SamplingError>
     {
         // Sanity check that read coordinates are in bounds
-        if (x > self.size.0 as i32) || (y > self.size.1 as i32) || (y < -1) || (x < -1) {
+        if (x > i32::from(self.size.0)) || (y > i32::from(self.size.1)) || (y < -1) || (x < -1) {
             return Err(SamplingError::ReadOutOfBounds())
         }
 
@@ -60,9 +60,9 @@ impl<'a> HeightmapData for TextureHeightmap<'a>
 
         // Work of the coordinate in the data array of the bytes for this pixel
         let i = x                               // Offset by columns
-              + y * (self.size.1 as i32 + 2);   // Offset by rows
+              + y * (i32::from(self.size.1) + 2);   // Offset by rows
 
         // Get the byte
-        Ok(self.texture.data[i as usize] as f32)
+        Ok(f32::from(self.texture.data[i as usize]))
     }
 }

--- a/src/land/heightmap.rs
+++ b/src/land/heightmap.rs
@@ -34,10 +34,10 @@ impl<'a> TextureHeightmap<'a> {
             return Err(WrapError::UnsupportedFormat(texture.format));
         }
 
-        return Ok(TextureHeightmap {
+        Ok(TextureHeightmap {
             texture,
             size: (texture.size.x() as u32 - 2, texture.size.y() as u32 - 2),
-        });
+        })
     }
 }
 
@@ -50,7 +50,7 @@ impl<'a> HeightmapData for TextureHeightmap<'a>
     fn sample(&self, x:i32, y:i32) -> Result<f32, SamplingError>
     {
         // Sanity check that read coordinates are in bounds
-        if (x >= self.size.0 as i32 + 1) || (y > self.size.1 as i32 + 1) || (y < -1) || (x < -1) {
+        if (x > self.size.0 as i32) || (y > self.size.1 as i32) || (y < -1) || (x < -1) {
             return Err(SamplingError::ReadOutOfBounds())
         }
 

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -6,11 +6,11 @@ use super::heightmap::HeightmapData;
 
 struct QuadPatchGenerator {
     idx: usize,
-    values: [u32; 6]
+    values: [u16; 6]
 }
 
 impl QuadPatchGenerator {
-    fn new(base_idx: u32, width: u32) -> QuadPatchGenerator {
+    fn new(base_idx: u16, width: u16) -> QuadPatchGenerator {
         QuadPatchGenerator {
             idx: 0, 
             values: [
@@ -26,7 +26,7 @@ impl QuadPatchGenerator {
 }
 
 impl Iterator for QuadPatchGenerator {
-    type Item = u32;
+    type Item = u16;
 
     fn next(&mut self) -> Option<Self::Item> {
         let v = if self.idx >= 6 {
@@ -99,10 +99,8 @@ fn uvs(width: i32, height: i32) -> Vec<[f32; 2]> {
 }
 
 fn indices(width: u16, height: u16) -> Vec<u32> {
-    let width = u32::from(width);
-    let height = u32::from(height);
-    
     (0..height-1).cartesian_product(0..width-1)
         .flat_map(move |(z, x)| QuadPatchGenerator::new(x + z * width, width))
+        .map(u32::from)
         .collect::<Vec<_>>()
 }

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -4,12 +4,14 @@ use itertools::Itertools;
 
 use super::heightmap::HeightmapData;
 
+/// Iterator which generates a quad (two triangles) with the top left corner at a given idnex
 struct QuadPatchGenerator {
     idx: usize,
     values: [u16; 6]
 }
 
 impl QuadPatchGenerator {
+    /// Create a new quad patch generator for a grid with a given width, starting at base_idx
     fn new(base_idx: u16, width: u16) -> QuadPatchGenerator {
         QuadPatchGenerator {
             idx: 0, 
@@ -25,6 +27,7 @@ impl QuadPatchGenerator {
     }
 }
 
+/// Return the 6 indices for this quad
 impl Iterator for QuadPatchGenerator {
     type Item = u16;
 

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -67,13 +67,13 @@ pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::
             let u = sample(x, z + 1);
 
             // Calculate normal
-            let n = Vec3::new(
+            let norm = Vec3::new(
                 l - r,
                 d - u,
                 2f32
             ).normalize();
             
-            [n.x(), n.y(), n.z()]
+            [norm.x(), norm.y(), norm.z()]
         })
         .collect::<Vec<_>>();
 

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -1,75 +1,88 @@
 use bevy::{prelude::*, render::mesh::VertexAttribute};
 
-//takes a grayscale texture handle and returns a mesh with height based on the grayscale values
-pub fn texture_to_mesh(
-    textures: ResMut<Assets<Texture>>,
-    land_texture_handle: Handle<Texture>,
-) -> Option<Mesh> {
-    //gets a reference to the data needed
-    let land_texture = textures.get(&land_texture_handle)?;
+use rayon::iter::ParallelBridge;
+use rayon::prelude::ParallelIterator;
+use itertools::Itertools;
 
-    //prepares the Vecs with the capacity they need.
-    let mut land_positions =
-        Vec::with_capacity((land_texture.size.x() * land_texture.size.y()) as usize);
-    let mut land_normals =
-        Vec::with_capacity((land_texture.size.x() * land_texture.size.y()) as usize);
-    let mut land_uvs = Vec::with_capacity((land_texture.size.x() * land_texture.size.y()) as usize);
+use super::heightmap::HeightmapData;
 
-    let mut land_indices = Vec::with_capacity(
-        ((land_texture.size.x() - 1.0) * (land_texture.size.y() - 1.0)) as usize,
-    );
+struct QuadPatchGenerator {
+    idx: usize,
+    values: [u32; 6]
+}
 
-    //Loop through all pixels in the texture in their vertex order
-    for z in 0..(land_texture.size.y() as i32) {
-        for x in 0..land_texture.size.x() as i32 {
-            //index number for the current vertex
-            let i: u32 = x as u32 + z as u32 * land_texture.size.y() as u32;
-
-            //pushes the current Vertex's VertexAttributes to the correct Vecs.
-            //TODO(#28): Use sampler to get mipped height data, rather than using direct data
-            land_positions.push([
-                x as f32,
-                land_texture.data[i as usize] as f32 / 16.0,
-                z as f32,
-            ]);
-
-            //TODO(#27): Generate normals based on texture data
-            land_normals.push([0.0, 1.0, 0.0]);
-
-            land_uvs.push([
-                x as f32 / (land_texture.size.x() - 1.0),
-                z as f32 / (land_texture.size.y() - 1.0),
-            ]);
-
-            //For vertexes that aren't on the end edges, input 2 triangles into the triangle list, clockwise
-            if x != (land_texture.size.x() - 1.0) as i32
-                && z != (land_texture.size.y() - 1.0) as i32
-            {
-                land_indices.push(i);
-                land_indices.push(i + land_texture.size.x() as u32);
-                land_indices.push(i + land_texture.size.x() as u32 + 1);
-
-                land_indices.push(i);
-                land_indices.push(i + land_texture.size.x() as u32 + 1);
-                land_indices.push(i + 1);
-            }
+impl QuadPatchGenerator {
+    fn new(base_idx: u32, width: u32) -> QuadPatchGenerator {
+        QuadPatchGenerator {
+            idx: 0, 
+            values: [
+                base_idx,
+                base_idx + width,
+                base_idx + 1,
+                base_idx + width,
+                base_idx + width + 1,
+                base_idx + 1
+            ]
         }
     }
+}
+
+impl Iterator for QuadPatchGenerator {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let v = if self.idx >= 6 {
+            None
+        } else {
+            Some(self.values[self.idx])
+        };
+        self.idx += 1;
+
+        return v;
+    }
+}
+
+//takes a grayscale texture handle and returns a mesh with height based on the grayscale values
+pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::Error>>
+    where T: HeightmapData
+{
+    let width = land_texture.size().0;
+    let height = land_texture.size().1;
+
+    // Generate UVs
+    let uvs = (0..height).cartesian_product(0..width)
+        .map(move |(z, x)| [x as f32 / (width - 1) as f32, z as f32 / (height - 1) as f32])
+        .collect::<Vec<_>>();
+
+    // Generate positions
+    let positions = (0..height).cartesian_product(0..width)
+        .map(move |(z, x)| [x as f32, land_texture.sample(x, z).expect("Failed to sample heightmap") as f32 / 16.0, z as f32])
+        .collect::<Vec<_>>();
+
+    // Generate indices
+    let indices = (0..height).cartesian_product(0..width)
+        .flat_map(move |(z, x)| QuadPatchGenerator::new(x + z * width, width))
+        .collect::<Vec<_>>();
+
+    // todo(#27): Generate normals
+    let normals = (0..height).cartesian_product(0..width)
+        .map(move |(z, x)| [0.0, 1.0, 0.0])
+        .collect::<Vec<_>>();
 
     //Generates the mesh from the information generated above using bevy's mesh generators
     let land_mesh = Mesh {
         primitive_topology: bevy::render::pipeline::PrimitiveTopology::TriangleList,
         attributes: vec![
-            VertexAttribute::position(land_positions),
-            VertexAttribute::normal(land_normals),
-            VertexAttribute::uv(land_uvs),
+            VertexAttribute::position(positions),
+            VertexAttribute::normal(normals),
+            VertexAttribute::uv(uvs),
         ],
-        indices: Some(land_indices),
+        indices: Some(indices),
     };
 
-    Some(land_mesh)
+    return Ok(land_mesh);
 }
 
-//TODO(#26): fn pub land_pipeline (Creates a render pipeline set up to use Uint32s for vertex indices)
+//TODO: fn pub land_pipeline (Creates a render pipeline set up to use Uint32s for vertex indices)
 //Note: May also include Vert shader that adds some roughness/recalculates normals and Frag shader that
 //      adds some subtle color based on height or distance from camera

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -36,7 +36,7 @@ impl Iterator for QuadPatchGenerator {
         };
         self.idx += 1;
 
-        return v;
+        v
     }
 }
 
@@ -73,7 +73,7 @@ pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::
                 2f32
             ).normalize();
             
-            return [n.x(), n.y(), n.z()];
+            [n.x(), n.y(), n.z()]
         })
         .collect::<Vec<_>>();
 
@@ -88,19 +88,20 @@ pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::
         indices: Some(indices(width, height)),
     };
 
-    return Ok(land_mesh);
+    Ok(land_mesh)
 }
 
 fn uvs(width: i32, height: i32) -> Vec<[f32; 2]> {
-    return (0..height).cartesian_product(0..width)
+    (0..height).cartesian_product(0..width)
         .map(move |(z, x)| [x as f32 / (width - 1) as f32, z as f32 / (height - 1) as f32])
-        .collect::<Vec<_>>();
+        .collect::<Vec<_>>()
 }
 
 fn indices(width: i32, height: i32) -> Vec<u32> {
     let width = width as u32;
     let height = height as u32;
-    return (0..height-1).cartesian_product(0..width-1)
+    
+    (0..height-1).cartesian_product(0..width-1)
         .flat_map(move |(z, x)| QuadPatchGenerator::new(x + z * width, width))
-        .collect::<Vec<_>>();
+        .collect::<Vec<_>>()
 }

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -73,8 +73,8 @@ pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::
             // Calculate normal
             let norm = Vec3::new(
                 l - r,
-                d - u,
-                2f32
+                2f32,
+                d - u
             ).normalize();
             
             [norm.x(), norm.y(), norm.z()]

--- a/src/land/mesh.rs
+++ b/src/land/mesh.rs
@@ -44,12 +44,13 @@ impl Iterator for QuadPatchGenerator {
 pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::Error>>
     where T: HeightmapData
 {
-    let width = land_texture.size().0 as i32;
-    let height = land_texture.size().1 as i32;
+
+    let width = i32::from(land_texture.size().0);
+    let height = i32::from(land_texture.size().1);
 
     // Define a helper to sample the underlying data
     let sample = |x, z| {
-        land_texture.sample(x, z).expect("Failed to sample heightmap") as f32 / 16.0
+        land_texture.sample(x, z).expect("Failed to sample heightmap") / 16.0
     };
 
     // Generate positions
@@ -85,7 +86,7 @@ pub fn texture_to_mesh<T>(land_texture: &T) -> Result<Mesh, Box<dyn std::error::
             VertexAttribute::normal(normals),
             VertexAttribute::uv(uvs(width, height)),
         ],
-        indices: Some(indices(width, height)),
+        indices: Some(indices(land_texture.size().0, land_texture.size().1)),
     };
 
     Ok(land_mesh)
@@ -97,9 +98,9 @@ fn uvs(width: i32, height: i32) -> Vec<[f32; 2]> {
         .collect::<Vec<_>>()
 }
 
-fn indices(width: i32, height: i32) -> Vec<u32> {
-    let width = width as u32;
-    let height = height as u32;
+fn indices(width: u16, height: u16) -> Vec<u32> {
+    let width = u32::from(width);
+    let height = u32::from(height);
     
     (0..height-1).cartesian_product(0..width-1)
         .flat_map(move |(z, x)| QuadPatchGenerator::new(x + z * width, width))

--- a/src/land/mod.rs
+++ b/src/land/mod.rs
@@ -1,6 +1,5 @@
-mod land;
-
 mod heightmap;
 pub use heightmap::TextureHeightmap;
 
-pub use land::*;
+mod mesh;
+pub use mesh::texture_to_mesh;

--- a/src/land/mod.rs
+++ b/src/land/mod.rs
@@ -1,6 +1,5 @@
 mod land;
 
-mod bintree;
 mod heightmap;
 pub use heightmap::TextureHeightmap;
 

--- a/src/land/mod.rs
+++ b/src/land/mod.rs
@@ -1,1 +1,7 @@
-pub mod mesh;
+mod land;
+
+mod bintree;
+mod heightmap;
+pub use heightmap::TextureHeightmap;
+
+pub use land::*;


### PR DESCRIPTION
Main change is that the landscape now has normal data (Resolve #27).
 - This generates a map for all pixels in the heightmap _except_ a one px border all around. This is so that the pixels from the next tile over can be stored there (allowing seamless normals).
 - Rewritten generation to be based on iterators. I was planning to use parallel iterators etc to generate all data channels simultaneously, but that turned out to be a pain in the ass.

Also some other changes that will make implementing #31 (my next task) easier:
 - Wrapped heightmap data sources in a HeightmapData trait. This allows heightmaps to be stored in things besides textures (e.g. a 2D array downloaded form the server).
 - Implemented HeightmapData for a wrapper around textures (still requires 8bit grayscale textures only).